### PR TITLE
Keep after <C-r>=

### DIFF
--- a/autoload/cmdline.vim
+++ b/autoload/cmdline.vim
@@ -204,7 +204,9 @@ function cmdline#enable() abort
 
   augroup cmdline
     autocmd CmdlineEnter,CmdlineChanged * ++nested call s:redraw_cmdline()
-    autocmd CmdlineLeave,VimLeavePre * ++nested call cmdline#disable()
+    " NOTE: CmdlineLeave is also triggered on `<C-r>=`.
+    autocmd ModeChanged c:[^c] ++nested call cmdline#disable()
+    autocmd VimLeavePre * ++nested call cmdline#disable()
   augroup END
 
   if '##CursorMovedC'->exists()


### PR DESCRIPTION
Fix this.
- Steps
  In Vim, `:<C-r>=`, input any and `<CR>`
- Expect Behavior
  Keep floating the floating window.
- Actual Behavior
  The floating window is closed.

CmdlineLeave is also triggered on `<C-r>=`.
Use ModeChanged instead of CmdlineLeabe to fix this.